### PR TITLE
Standalone projector cli.

### DIFF
--- a/projector-cli/README.md
+++ b/projector-cli/README.md
@@ -1,0 +1,102 @@
+# Projector Command Line
+
+There are a few command line tools for projector at the moment, and
+all are probably a work in progress. The `projector` executable is
+the closest to a project ready tool for building tools, and is used
+in anger by a number of projector users.
+
+### Usage
+
+Long form.
+```
+projector \
+  --templates template-dir \    # directory containing projector (.prj) and machinator (.mcn) files.
+  --examples examples-dir \     # directory containing projector (.prj) files requiring no arguments.
+  --haskell-output gen \        # directory to generate haskell output (from --templates).
+  --html-output html \          # directory to generate html examples (from --examples).
+  --module-prefix Project \     # specified module prefix for haskell code.
+  --watch                       # run the compilation in a loop, watching for file changes.
+```
+
+Short form.
+```
+projector \
+  -t template-dir \             # directory containing projector (.prj) and machinator (.mcn) files.
+  -e examples-dir \             # directory containing projector (.prj) files requiring no arguments.
+  -o gen \                      # directory to generate haskell output (from --templates).
+  -h html \                     # directory to generate html examples (from --examples).
+  -m Project \                  # specified module prefix for haskell code.
+  -w                            # run the compilation in a loop, watching for file changes.
+```
+
+### Conventions
+
+The projector cli uses the following conventions.
+
+
+Given a template + data types files:
+
+```
+examples-dir/examples/form.prj
+template-dir/components/form.prj
+template-dir/components/form.mcn
+```
+
+
+Running projector with:
+```
+projector -t template-dir -e examples-dir -o gen -h examples -m Project
+```
+
+Templates refer to names using paths so there is no tranlsation:
+```
+components/form
+```
+
+Haskell code gen generates a module name (with specified prefix) and camel case:
+```
+Project.Components.Form.componentsForm
+```
+
+Data types are generated in a `.Data` suffixed module:
+```
+Project.Components.Form.Data
+```
+
+### Development Loops
+
+If working on html/styling of components, it is recommended that you create an example
+with no arguments that can be turned straight into html. See `test/examples/example.prj`
+for an example.
+
+Once you have example html generating, you can just serve the files up. An example of
+a caddy configuration that does this:
+```
+localhost:30080
+browse
+log stdout
+```
+
+If you need to specify a path to css assets or similar, you can add a rewrite rule:
+```
+rewrite /assets/.* /static/{path}
+```
+
+If you are doing haskell development you can use ghci and ctrl+r, or if you want
+to have automatic reloading you can run `ghcid` with `Rapid.restart`. To do this
+in the main module that starts your web server:
+
+```
+import qualified Rapid
+
+_update :: IO ()
+_update = do
+  Rapid.rapid 0 $ \r ->
+    Rapid.restart r ("server" :: [Char]) run -- Where run starts your server.
+```
+
+Then run `ghcid` with something like:
+
+```
+ghcid -- -T Main._update
+```

--- a/projector-cli/bin/run-test
+++ b/projector-cli/bin/run-test
@@ -1,0 +1,12 @@
+#!/bin/sh -eu
+
+rm -rf test/haskell test/html
+
+dist/build/projector/projector \
+  -t test/templates \
+  -e test/examples \
+  -o test/haskell \
+  -h test/html \
+  -m Example.Project \
+  -v \
+  -w

--- a/projector-cli/main/cinema.hs
+++ b/projector-cli/main/cinema.hs
@@ -135,7 +135,7 @@ cinemaBuild b mb msp tg mdg o = do
   ba <- hoistEither (first BuildError (runBuild b udts mempty rts))
   out <- maybe (pure mempty) (\b' -> hoistEither (first BackendError (codeGen (getBackend b') codeGenNamerSimple mempty ba))) mb
   -- Write out any artefacts
-  liftIO . for_ out $ \(f, body) -> do
+  liftIO . for_ out $ \(_, f, body) -> do
     let ofile = o </> f
     IO.putStrLn ("Generating " <> ofile)
     createDirectoryIfMissing True (takeDirectory ofile)

--- a/projector-cli/main/projector.hs
+++ b/projector-cli/main/projector.hs
@@ -1,0 +1,399 @@
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE DoAndIfThenElse #-}
+
+import qualified BuildInfo_projector_cli as BuildInfo
+
+import           Control.Applicative (many)
+import qualified Control.Concurrent as Concurrent
+import qualified Control.Concurrent.MVar as MVar
+import qualified Control.Monad.Catch as Catch
+import           Control.Monad.IO.Class (MonadIO (..))
+
+import qualified Data.List as List
+import qualified Data.Map as Map
+import           Data.Set (Set)
+import qualified Data.Set as Set
+import           Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.IO as Text
+
+import           Options.Applicative ((<**>))
+import qualified Options.Applicative as Options
+
+import qualified Projector.Core as Projector
+import qualified Projector.Html as Projector
+import qualified Projector.Html.Backend.Haskell as Haskell
+import qualified Projector.Html.Core.Machinator as Projector
+import qualified Projector.Html.Data.Module as Projector
+import qualified Projector.Html.Interpreter as Interpreter
+import qualified Projector.Html.Interpreter.Hydrant as Interpreter
+import qualified Projector.Html.Machinator as Machinator
+
+import           Projector.Core.Prelude
+
+import qualified System.Directory as Directory
+import           System.FilePath ((</>))
+import qualified System.FilePath as FilePath
+import           System.FilePath.Find ((==?))
+import qualified System.FilePath.Find as Find
+import qualified System.FSNotify as Notify
+import           System.IO (IO, FilePath)
+import qualified System.IO as IO
+import qualified System.Exit as Exit
+
+data Watch =
+    Watch
+  | NoWatch
+    deriving (Eq, Ord, Show)
+
+data Verbose =
+    Verbose
+  | Quiet
+    deriving (Eq, Ord, Show)
+
+newtype TemplateDirectory =
+  TemplateDirectory {
+      templateDirectory :: FilePath
+    } deriving (Eq, Ord, Show)
+
+newtype HaskellDirectory =
+    HaskellDirectory FilePath
+    deriving (Eq, Ord, Show)
+
+newtype ExampleDirectory =
+    ExampleDirectory FilePath
+    deriving (Eq, Ord, Show)
+
+data RelativeFileContent a =
+    RelativeFileContent FilePath a
+    deriving (Eq, Ord, Show, Functor)
+
+data Command =
+    Command Verbose Watch [TemplateDirectory] [TemplateDirectory] (Maybe HaskellDirectory) (Maybe ExampleDirectory) (Maybe Projector.ModuleName)
+  | Version
+    deriving (Eq, Ord, Show)
+
+data Error =
+    ErrorMessage Text
+  | HaskellErrors [Haskell.HaskellError]
+  | HtmlErrors [Projector.HtmlError]
+  | MachinatorError Machinator.MachinatorError
+    deriving (Eq, Show)
+
+renderError :: Error -> Text
+renderError err =
+  case err of
+    ErrorMessage message ->
+      mconcat ["[projector:build:error] ", message]
+    HaskellErrors errors ->
+      Text.unlines . join $ [
+          ["[projector:build:error] error generating haskell"]
+        , Haskell.renderHaskellError <$> errors
+        ]
+    HtmlErrors errors ->
+      Text.unlines . join $ [
+          ["[projector:build:error] error compiling templates"]
+        , Projector.renderHtmlError <$> errors
+        ]
+    MachinatorError e ->
+      Text.unlines [
+          "[projector:build:error] error compiling data types"
+        , Machinator.renderMachinatorError e
+        ]
+
+parser :: Options.Parser Command
+parser =
+  Command
+    <$> pverbose
+    <*> pwatch
+    <*> many ptemplates
+    <*> many pexamples
+    <*> Options.optional phaskell
+    <*> Options.optional phtml
+    <*> Options.optional pmodulePrefix
+
+main :: IO ()
+main = do
+  IO.hSetBuffering IO.stdout IO.LineBuffering
+  IO.hSetBuffering IO.stderr IO.LineBuffering
+  dispatch (Version <$ pversion <|> parser) >>= \command ->
+    case command of
+      Command verbose NoWatch templates examples haskell html prefix ->
+        runEitherT (run verbose templates examples haskell html prefix) >>= \r ->
+          case r of
+            Left err -> do
+              Text.hPutStrLn IO.stderr $ renderError err
+              Exit.exitFailure
+            Right _ ->
+              Exit.exitSuccess
+      Command verbose Watch templates examples haskell html prefix ->
+        watch verbose templates examples haskell html prefix
+      Version ->
+        Text.putStrLn . mconcat $ ["projector-", Text.pack BuildInfo.buildInfoVersion]
+
+watch :: Verbose -> [TemplateDirectory] -> [TemplateDirectory] -> Maybe HaskellDirectory -> Maybe ExampleDirectory -> Maybe Projector.ModuleName -> IO ()
+watch verbose templates examples haskell html prefix = do
+  lock <- MVar.newMVar ()
+  let
+    conf =
+      Notify.defaultConfig { Notify.confDebounce = Notify.Debounce 0.1 }
+    exploded e =
+      log . mconcat $ ["[projector:explosion] ", Text.pack . show $ e]
+    errored e =
+      log . renderError $ e
+    handler =
+      (\(e :: Catch.SomeException) -> exploded e)
+    safely =
+      Catch.handle handler (runEitherT (run verbose templates examples haskell html prefix) >>= either errored (const $ pure ()))
+    check x =
+      and [
+          not (List.isInfixOf ".#" $ Notify.eventPath x)
+        , (List.isSuffixOf ".prj" $ Notify.eventPath x) || (List.isSuffixOf ".mcn" $ Notify.eventPath x)
+        ]
+  runEitherT (run verbose templates examples haskell html prefix) >>= either errored (const $ pure ())
+  void . Notify.withManagerConf conf $ \manager -> do
+    for_ (templates <> examples) $ \(TemplateDirectory template) -> do
+      log $ mconcat ["[projector:watch] watching directory ", Text.pack template]
+      void $ Notify.watchTree manager template check (const $ MVar.withMVar lock . const $ safely)
+    forever $ Concurrent.threadDelay 1000000
+
+machinators :: [TemplateDirectory] -> EitherT Error IO [RelativeFileContent Machinator.DefinitionFile]
+machinators templates = do
+  mcns <- liftIO $ gatherBy templates ".mcn"
+  for mcns $ \mcn -> do
+    machinator <- liftIO $ Text.readFile mcn
+    Machinator.Versioned _ (Machinator.DefinitionFile _file definitions) <-
+      firstT MachinatorError . newEitherT . pure $
+        Machinator.parseDefinitionFile mcn machinator
+    pure $ RelativeFileContent mcn $ Machinator.DefinitionFile mcn definitions
+
+projectors :: [TemplateDirectory] -> IO [RelativeFileContent Text]
+projectors templates =  do
+  prjs <- gatherBy templates ".prj"
+  for prjs $ \prj -> do
+    RelativeFileContent prj <$> Text.readFile prj
+
+examplars :: [TemplateDirectory] -> [FilePath] -> Maybe Projector.ModuleName -> IO (Set Projector.ModuleName)
+examplars templates absolutes prefix =  do
+  examples <- liftIO $ gatherBy templates ".prj"
+  pure . Set.fromList . with examples $
+    Projector.pathToModuleName (moduleNamer absolutes prefix)
+
+absolutize :: [TemplateDirectory] -> IO [FilePath]
+absolutize templates =
+  for (templateDirectory <$> templates) $ fmap (<> "/") . Directory.makeAbsolute
+
+run :: Verbose -> [TemplateDirectory] -> [TemplateDirectory] -> Maybe HaskellDirectory -> Maybe ExampleDirectory -> Maybe Projector.ModuleName -> EitherT Error IO ()
+run verbose templates examples haskells htmls prefix = do
+  detail verbose "[projector:build:begin]"
+
+  absolutes <- liftIO $ absolutize (templates <> examples)
+  mcns <- machinators (templates <> examples)
+  prjs <- liftIO $ projectors (templates <> examples)
+  exas <- liftIO $ examplars examples absolutes prefix
+
+  let
+    declarations =
+      with mcns $ \(RelativeFileContent mcn (Machinator.DefinitionFile _ definitions)) ->
+        (mcn,  Projector.unTypeDecls . Projector.machinatorDecls $ definitions)
+
+    plain =
+      Projector.machinatorDecls $
+        mcns >>= \(RelativeFileContent _ (Machinator.DefinitionFile _ definitions)) -> definitions
+
+  artefacts <- firstT HtmlErrors . hoistEither $
+    Projector.runBuild
+      (Projector.Build (moduleNamer absolutes prefix) [])
+      (Projector.UserDataTypes declarations)
+      (Projector.UserConstants Map.empty)
+      (Projector.RawTemplates $ with prjs $ \(RelativeFileContent prj raw) -> (prj, raw))
+
+  firstT HtmlErrors . hoistEither $
+    Projector.warnModules plain $ Projector.buildArtefactsHtmlModules artefacts
+
+  code <- firstT HaskellErrors . hoistEither $
+    Projector.codeGen
+      Haskell.haskellBackend
+      (codeGenNamer absolutes)
+      (Projector.PlatformConstants Map.empty)
+      artefacts
+
+  detail verbose "[projector:build:html]"
+
+  liftIO $ for_ (Map.toList $ Projector.buildArtefactsHtmlModules $ artefacts) $ \(name, modulex) ->
+    when (Set.member name exas) $ do
+      for_ htmls $ \(ExampleDirectory d) -> do
+        for_ (Map.elems $ Projector.moduleExprs modulex) $ \(Projector.ModuleExpr _ty expr) ->
+          case Interpreter.interpret plain (Projector.extractModuleExprs . Projector.buildArtefactsHtmlModules $ artefacts) expr of
+            Left _ ->
+              pure ()
+            Right html -> do
+              writeOnChange (d </> (Text.unpack . Projector.unModuleName $ name) <> ".html") (Interpreter.toText html)
+
+  detail verbose "[projector:build:haskell]"
+
+  for_ haskells $ \(HaskellDirectory d) ->
+    liftIO $ forM_ code $ \(m, name, haskell) -> do
+      unless (Set.member m exas) $
+        writeOnChange (d </> name) haskell
+
+  log "[projector:build:done]"
+
+
+log :: MonadIO m => Text -> m ()
+log msg =
+  liftIO $ Text.hPutStrLn IO.stderr msg
+
+detail :: MonadIO m => Verbose -> Text -> m ()
+detail v msg =
+  case v of
+    Verbose ->
+      liftIO $ Text.hPutStrLn IO.stderr msg
+    Quiet ->
+      pure ()
+
+gatherBy :: [TemplateDirectory] -> FilePath -> IO [FilePath]
+gatherBy templates extension =
+  fmap join . for templates $ \t ->
+    gather t extension
+
+gather :: TemplateDirectory -> FilePath -> IO [FilePath]
+gather (TemplateDirectory directory) extension = do
+  exists <- Directory.doesDirectoryExist directory
+  if not exists then
+    pure []
+  else do
+    absolute <- Directory.makeAbsolute directory
+    Find.find Find.always (Find.extension ==? extension) directory >>= \files ->
+      (pure . with files $ \file ->
+        absolute </> FilePath.makeRelative directory file)
+
+stripPrefix :: [FilePath] -> FilePath -> FilePath
+stripPrefix prefixes  path =
+  foldr (\el acc -> maybe acc id $ List.stripPrefix el acc) path (List.reverse . List.sortOn length $ prefixes)
+
+-- Note: This obtuse namer ensures that we can use absolute FilePath's but get
+-- sensible names out. Absolute paths are required to generate error messages
+-- that make sense. Sensible names, are sensible. It uses the provided prefixes
+-- to relativise the module paths as it constructs the name.
+-- Note: Module names are Dot.Separated.TitleCase
+-- Note: Expression names are slash/separated/file-paths
+moduleNamer :: [FilePath] -> Maybe Projector.ModuleName -> Projector.ModuleNamer
+moduleNamer prefixes prefix =
+  let
+    defaultModuleNamer =
+      Projector.moduleNamerSimple prefix
+  in
+    defaultModuleNamer {
+       Projector.pathToModuleName =
+         Projector.pathToModuleName defaultModuleNamer . stripPrefix prefixes
+     , Projector.pathToDataModuleName =
+         Projector.pathToDataModuleName defaultModuleNamer . stripPrefix prefixes
+     , Projector.filePathToExprName =
+         Projector.Name . Text.pack . FilePath.dropExtension . stripPrefix prefixes
+     }
+
+-- Note: See moduleNamer for absolute path name explanation.
+-- Note: Backend names are camel case, i.e. slashSeparatedFilePaths produced from slash/separated/file-paths.
+codeGenNamer :: [FilePath] -> Projector.CodeGenNamer
+codeGenNamer prefixes =
+  Projector.CodeGenNamer {
+      Projector.templateDefToBackendDef =
+        \n _ _ ->
+          Projector.filePathToExprNameSimple . stripPrefix prefixes . Text.unpack . Projector.unName $ n
+    , Projector.templateNameToBackendName =
+        \n _ _ ->
+          Projector.filePathToExprNameSimple . stripPrefix prefixes . Text.unpack . Projector.unName $ n
+    }
+
+writeOnChange :: FilePath -> Text -> IO ()
+writeOnChange path content = do
+  Directory.createDirectoryIfMissing True (FilePath.takeDirectory path)
+  exists <- Directory.doesFileExist path
+  case exists of
+    False ->
+      Text.writeFile path content
+    True -> do
+      old <- Text.readFile path
+      when (old /= content) $
+        Text.writeFile path content
+
+dispatch :: Options.Parser a -> IO a
+dispatch p = do
+  Options.customExecParser
+    (Options.prefs . mconcat $ [
+        Options.showHelpOnEmpty
+      , Options.showHelpOnError
+      ])
+    (Options.info
+      (p <**> Options.helper)
+      (mconcat [
+          Options.fullDesc
+        , Options.progDesc "Compile projector templates to haskell or html."
+        , Options.header "projector template compiler."
+        ]))
+
+pwatch :: Options.Parser Watch
+pwatch =
+  Options.flag NoWatch Watch . mconcat $ [
+      Options.long "watch"
+    , Options.short 'w'
+    ]
+
+pverbose :: Options.Parser Verbose
+pverbose =
+  Options.flag Quiet Verbose . mconcat $ [
+      Options.long "verbose"
+    , Options.short 'v'
+    ]
+
+ptemplates :: Options.Parser TemplateDirectory
+ptemplates =
+  fmap TemplateDirectory . Options.strOption . mconcat $ [
+      Options.long "templates"
+    , Options.short 't'
+    , Options.metavar "DIRECTORY"
+    ]
+
+pexamples :: Options.Parser TemplateDirectory
+pexamples =
+  fmap TemplateDirectory . Options.strOption . mconcat $ [
+      Options.long "examples"
+    , Options.short 'e'
+    , Options.metavar "DIRECTORY"
+    ]
+
+phaskell :: Options.Parser HaskellDirectory
+phaskell =
+  fmap HaskellDirectory . Options.strOption . mconcat $ [
+      Options.long "haskell-output"
+    , Options.short 'o'
+    , Options.metavar "DIRECTORY"
+    ]
+
+phtml :: Options.Parser ExampleDirectory
+phtml =
+  fmap ExampleDirectory . Options.strOption . mconcat $ [
+      Options.long "html-output"
+    , Options.short 'h'
+    , Options.metavar "DIRECTORY"
+    ]
+
+pmodulePrefix :: Options.Parser Projector.ModuleName
+pmodulePrefix =
+  fmap (Projector.ModuleName . Text.pack) . Options.strOption . mconcat $ [
+      Options.long "module-prefix"
+    , Options.short 'm'
+    , Options.metavar "MODULE"
+    ]
+
+pversion :: Options.Parser ()
+pversion =
+  Options.flag' () . mconcat $ [
+      Options.short 'V'
+    , Options.long "version"
+    , Options.help "Version information"
+    ]

--- a/projector-cli/projector-cli.cabal
+++ b/projector-cli/projector-cli.cabal
@@ -70,6 +70,36 @@ executable slideshow
                        BuildInfo_projector_cli
                        DependencyInfo_projector_cli
 
+executable projector
+  hs-source-dirs:     gen
+  main-is:            ../main/projector.hs
+  ghc-options:         -Wall -threaded
+
+  build-depends:
+                       base
+                     , projector-core
+                     , projector-html
+                     , projector-html-haskell
+                     , projector-html-purs
+                     , bytestring
+                     , containers
+                     , directory
+                     , exceptions
+                     , filepath
+                     , filemanip                       == 0.3.*
+                     , fsnotify                        == 0.2.*
+                     , text
+                     , transformers
+                     , optparse-applicative            >= 0.11 && < 0.15
+
+  other-modules:
+                       BuildInfo_projector_cli
+                       DependencyInfo_projector_cli
+  autogen-modules:
+                       BuildInfo_projector_cli
+                       DependencyInfo_projector_cli
+
+
 custom-setup
   setup-depends:
     base, Cabal

--- a/projector-cli/test/.gitignore
+++ b/projector-cli/test/.gitignore
@@ -1,0 +1,2 @@
+/haskell
+/html

--- a/projector-cli/test/examples/example.prj
+++ b/projector-cli/test/examples/example.prj
@@ -1,0 +1,3 @@
+layout/basic {
+    components/message (Message "yoyo")
+  }

--- a/projector-cli/test/templates/components/message.mcn
+++ b/projector-cli/test/templates/components/message.mcn
@@ -1,0 +1,6 @@
+-- machinator @ v3
+
+
+record Message = {
+    content : String
+  }

--- a/projector-cli/test/templates/components/message.prj
+++ b/projector-cli/test/templates/components/message.prj
@@ -1,0 +1,3 @@
+\ message : Message -> Html =
+
+<h1>{{message.content}}</h1>

--- a/projector-cli/test/templates/layout/basic.prj
+++ b/projector-cli/test/templates/layout/basic.prj
@@ -1,0 +1,10 @@
+\ body : Html -> Html =
+
+<html lang="en">
+  <head>
+    <title>Projector Test</title>
+  </head>
+  <body>
+    { body }
+  </body>
+</html>

--- a/projector-html-purs/test/Test/IO/Projector/Html/Backend/Purescript.hs
+++ b/projector-html-purs/test/Test/IO/Projector/Html/Backend/Purescript.hs
@@ -64,11 +64,11 @@ baseDecls =
 
 moduleProp :: HtmlDecls -> ModuleName -> Module HtmlType PrimT (HtmlType, a) -> PropertyT IO ()
 moduleProp decls mn =
-  uncurry pscProp . either (fail . show) id . Html.codeGenModule purescriptBackend decls mn
+  uncurry pscProp . either (fail . show) id . fmap pluck . Html.codeGenModule purescriptBackend decls mn
 
 modulePropCheck :: HtmlDecls -> ModuleName -> Module (Maybe HtmlType) PrimT SrcAnnotation -> PropertyT IO ()
 modulePropCheck decls mn modl@(Module tys _ _) =
-  uncurry pscProp . either (fail . T.unpack) id $ do
+  uncurry pscProp . either (fail . T.unpack) id . fmap pluck $ do
     modl' <- first Html.renderHtmlError (Html.checkModule tys mempty modl)
     first renderPurescriptError (Html.codeGenModule purescriptBackend decls mn modl')
 
@@ -80,6 +80,9 @@ pscProp mname modl =
       in readCreateProcessWithExitCode crpr [])
     (processProp (const success))
 
+pluck :: (a, b, c) -> (b, c)
+pluck (_, b, c) =
+  (b, c)
 
 once :: PropertyT IO () -> Property
 once =

--- a/projector-html/src/Projector/Html.hs
+++ b/projector-html/src/Projector/Html.hs
@@ -43,6 +43,8 @@ module Projector.Html (
   , HtmlExpr
   , moduleNamerSimple
   , codeGenNamerSimple
+  , filePathToModuleNameSimple
+  , filePathToExprNameSimple
   ) where
 
 
@@ -211,7 +213,7 @@ codeGen ::
   -> CodeGenNamer
   -> PlatformConstants
   -> BuildArtefacts
-  -> Either [e] [(FilePath, Text)]
+  -> Either [e] [(HB.ModuleName, FilePath, Text)]
 codeGen backend cgn pcons (BuildArtefacts decls nmap checked) = do
   -- Run the backend's validation predicates
   validateModules backend checked
@@ -225,9 +227,12 @@ codeGenModule ::
   -> HtmlDecls
   -> HB.ModuleName
   -> HB.Module HtmlType PrimT (HtmlType, a)
-  -> Either e (FilePath, Text)
-codeGenModule =
-  HB.renderModule
+  -> Either e (HB.ModuleName, FilePath, Text)
+codeGenModule b decls name m =
+  let
+    includeModuleName (p, t) = (name, p, t)
+  in
+    includeModuleName <$> HB.renderModule b decls name m
 
 -- | Apply a 'CodeGenNamer' to some module.
 codeGenRename :: TemplateNameMap -> CodeGenNamer -> HB.Module a b c -> HB.Module a b c


### PR DESCRIPTION
@thumphries This is what I have actually been using projector with. If you wanted to leave it out, I can put it somewhere else, but it is probably useful for trying to use projector as it is now. 

It is built around my dev-loop, which is basically run this in `watch` mode in one directory, and then either `ghci`/`ghcid` if I am doing server dev, or just running `caddy` against the html examples if I am just messing with styling/html etc... 

There are a bunch of small things that each help a bit:
 - Only write files if they change, helps a lot with ghci reloads and also stop spurious reload storms with filewatchers.
 - Full filenames in error messages so any tooling people have for working with compiler errors works.
 - Less confusion/mucking about for template names, they are just relative to the directory you specify so you don't have to work out what to strip etc... (this could be just a me thing, but found the bits in pieces in loom and other places pretty opaque).
 - Generate html examples without too much fuss.

Anyway, let me know if you want me to put this up in its own repository rather than here, otherwise would be useful for me to keep it here so it can stay in sync until something better happens.